### PR TITLE
Update NAV_DATA: add projects, fix Charity API URL

### DIFF
--- a/docs/en/project/data.ts
+++ b/docs/en/project/data.ts
@@ -45,10 +45,22 @@ export const NAV_DATA: NavData[] = [
         link: 'https://askai.mcjpg.org/',
       },
       {
+        icon: '/logo.png',
+        title: 'ServerEditor',
+        desc: 'Quickly edit the member server list',
+        link: 'https://server-editor.mcjpg.dev/',
+      },
+      {
+        icon: '/logo.png',
+        title: 'Devop Platform',
+        desc: 'Get a free subdomain and community passport login integration',
+        link: 'https://dash.mcjpg.dev/',
+      },
+      {
         icon: '/logo_AI.png',
         title: 'Charity API',
         desc: 'Our public welfare large model API site',
-        link: 'https://charity-api.mcjpg.org/',
+        link: 'https://charity-api.mcjpg.dev/',
       },
       {
         icon: '/icons/project/Openlist.svg',

--- a/docs/lch/project/data.ts
+++ b/docs/lch/project/data.ts
@@ -45,10 +45,22 @@ export const NAV_DATA: NavData[] = [
         link: 'https://askai.mcjpg.org/',
       },
       {
+        icon: '/logo.png',
+        title: 'ServerEditor',
+        desc: '速編成員伺服器之列表',
+        link: 'https://server-editor.mcjpg.dev/',
+      },
+      {
+        icon: '/logo.png',
+        title: 'Devop Platform',
+        desc: '可取免費之次級域名及社群通行證登入',
+        link: 'https://dash.mcjpg.dev/',
+      },
+      {
         icon: '/logo_AI.png',
         title: 'Charity API',
         desc: '吾輩公益之大模型API站',
-        link: 'https://charity-api.mcjpg.org/',
+        link: 'https://charity-api.mcjpg.dev/',
       },
       {
         icon: '/icons/project/Openlist.svg',

--- a/docs/project/data.ts
+++ b/docs/project/data.ts
@@ -45,10 +45,22 @@ export const NAV_DATA: NavData[] = [
         link: 'https://askai.mcjpg.org/',
       },
       {
+        icon: '/logo.png',
+        title: 'ServerEditor',
+        desc: '快速编辑成员服服务器列表',
+        link: 'https://server-editor.mcjpg.dev/',
+      },
+      {
+        icon: '/logo.png',
+        title: 'Devop Platform',
+        desc: '获取免费的二级域名和社区通行证登录接入',
+        link: 'https://dash.mcjpg.dev/',
+      },
+      {
         icon: '/logo_AI.png',
         title: 'Charity API',
         desc: '我们的公益大模型API站点',
-        link: 'https://charity-api.mcjpg.org/',
+        link: 'https://charity-api.mcjpg.dev/',
       },
       {
         icon: '/icons/project/Openlist.svg',


### PR DESCRIPTION
Add two new NAV_DATA entries for ServerEditor and Devop Platform (icons, titles, descriptions and links). Also update the Charity API link from https://charity-api.mcjpg.org/ to https://charity-api.mcjpg.dev/ to point to the correct domain.