### PR TITLE
Update MCJPG SSO URL casing

### DIFF
--- a/docs/en/project/data.ts
+++ b/docs/en/project/data.ts
@@ -30,7 +30,7 @@ export const NAV_DATA: NavData[] = [
         icon: '/icons/project/casdoor.png',
         title: 'MCJPG Passport',
         desc: 'MCJPG unified account system',
-        link: 'https://sso.mcjpg.org/login/mcjpg/',
+        link: 'https://sso.mcjpg.org/login/MCJPG/',
       },
       {
         icon: '/icons/project/google-color.svg',

--- a/docs/lch/project/data.ts
+++ b/docs/lch/project/data.ts
@@ -30,7 +30,7 @@ export const NAV_DATA: NavData[] = [
         icon: '/icons/project/casdoor.png',
         title: 'MCJPG令牌',
         desc: 'MCJPG統一之身份管理系統',
-        link: 'https://sso.mcjpg.org/login/mcjpg/',
+        link: 'https://sso.mcjpg.org/login/MCJPG/',
       },
       {
         icon: '/icons/project/google-color.svg',

--- a/docs/project/data.ts
+++ b/docs/project/data.ts
@@ -30,7 +30,7 @@ export const NAV_DATA: NavData[] = [
         icon: '/icons/project/casdoor.png',
         title: 'MCJPG通行证',
         desc: 'MCJPG统一的账户系统',
-        link: 'https://sso.mcjpg.org/login/mcjpg/',
+        link: 'https://sso.mcjpg.org/login/MCJPG/',
       },
       {
         icon: '/icons/project/google-color.svg',


### PR DESCRIPTION
Fix the MCJPG SSO login link by changing /login/mcjpg/ to /login/MCJPG/ in documentation files to avoid case-sensitive URL issues. Files updated: docs/en/project/data.ts, docs/lch/project/data.ts, docs/project/data.ts.