### PR TITLE
Upgrade Claude model to claude-sonnet-5

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -104,7 +104,7 @@ jobs:
             务必使用中文输出审查结果
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
           settings: |
             {
               "env": {
@@ -211,7 +211,7 @@ jobs:
             务必使用中文输出审查结果
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
           settings: |
             {
               "env": {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,7 +51,7 @@ jobs:
   
           # Optional: Configure Claude's behavior with CLI arguments  
           claude_args: |  
-            --model claude-sonnet-4-6  
+            --model claude-sonnet-5  
             #   --auto-approve  
             #   --max-turns 10  
             #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"  


### PR DESCRIPTION
Replace occurrences of `claude-sonnet-4-6` with `claude-sonnet-5` in GitHub Actions workflows (.github/workflows/claude.yml and .github/workflows/claude-pr-review.yml). Updates the model used for CLI jobs and PR review jobs to the newer Claude model.