### PR TITLE
Update default status API URL

### DIFF
--- a/docs/.vitepress/theme/components/ServerList.vue
+++ b/docs/.vitepress/theme/components/ServerList.vue
@@ -337,7 +337,7 @@ const props = defineProps({
   },
   statusApiUrl: {
     type: String,
-    default: 'https://serverstatus.mcjpg.org/',
+    default: 'https://serverstatusapi.mcjpg.org/',
   },
   pollInterval: {
     type: Number,


### PR DESCRIPTION
Change default statusApiUrl in docs/.vitepress/theme/components/ServerList.vue from https://serverstatus.mcjpg.org/ to https://serverstatusapi.mcjpg.org/. Updates the component to use the new API hostname.