### PR TITLE
docs: add Mirror and ServerStatusAPI to project nav

### DIFF
--- a/docs/en/project/data.ts
+++ b/docs/en/project/data.ts
@@ -57,6 +57,12 @@ export const NAV_DATA: NavData[] = [
         link: 'https://dash.mcjpg.dev/',
       },
       {
+        icon: '/logo.png',
+        title: 'Mirror',
+        desc: 'Self-hosted Docker image service',
+        link: 'https://mirror.mcjpg.dev/',
+      },
+      {
         icon: '/logo_AI.png',
         title: 'Charity API',
         desc: 'Our public welfare large model API site',
@@ -79,6 +85,12 @@ export const NAV_DATA: NavData[] = [
         title: 'Community Image Hosting',
         desc: 'Quickly share images',
         link: 'https://image.mcjpg.org/',
+      },
+      {
+        icon: '/logo.png',
+        title: 'ServerStatusAPI',
+        desc: 'Distributed Minecraft server status monitoring',
+        link: 'https://github.com/MineJPGcraft/ServerStatusAPI',
       },
       {
         icon: '/icons/project/editor.svg',

--- a/docs/lch/project/data.ts
+++ b/docs/lch/project/data.ts
@@ -57,6 +57,12 @@ export const NAV_DATA: NavData[] = [
         link: 'https://dash.mcjpg.dev/',
       },
       {
+        icon: '/logo.png',
+        title: 'Mirror',
+        desc: '自營之Docker鏡像服務',
+        link: 'https://mirror.mcjpg.dev/',
+      },
+      {
         icon: '/logo_AI.png',
         title: 'Charity API',
         desc: '吾輩公益之大模型API站',
@@ -79,6 +85,12 @@ export const NAV_DATA: NavData[] = [
         title: '圖床',
         desc: '可速示畫與他人',
         link: 'https://image.mcjpg.org/',
+      },
+      {
+        icon: '/logo.png',
+        title: 'ServerStatusAPI',
+        desc: '分佈式之MC伺服器狀態勘察系統',
+        link: 'https://github.com/MineJPGcraft/ServerStatusAPI',
       },
       {
         icon: '/icons/project/editor.svg',

--- a/docs/project/data.ts
+++ b/docs/project/data.ts
@@ -57,6 +57,12 @@ export const NAV_DATA: NavData[] = [
         link: 'https://dash.mcjpg.dev/',
       },
       {
+        icon: '/logo.png',
+        title: 'Mirror',
+        desc: '自营Docker镜像服务',
+        link: 'https://mirror.mcjpg.dev/',
+      },
+      {
         icon: '/logo_AI.png',
         title: 'Charity API',
         desc: '我们的公益大模型API站点',
@@ -79,6 +85,12 @@ export const NAV_DATA: NavData[] = [
         title: '社区图床',
         desc: '快捷分享图片',
         link: 'https://image.mcjpg.org/',
+      },
+      {
+        icon: '/logo.png',
+        title: 'ServerStatusAPI',
+        desc: '分布式MC服务器状态监测系统',
+        link: 'https://github.com/MineJPGcraft/ServerStatusAPI',
       },
       {
         icon: '/icons/project/editor.svg',


### PR DESCRIPTION
Add two entries to docs/project data.ts: 'Mirror' (self-hosted Docker image service — https://mirror.mcjpg.dev/) and 'ServerStatusAPI' (distributed Minecraft server status monitoring — https://github.com/MineJPGcraft/ServerStatusAPI). These items are added to NAV_DATA so the site’s project list displays the new projects.